### PR TITLE
linspace creates values in a closed interval by default

### DIFF
--- a/L04/04_scipython__code.ipynb
+++ b/L04/04_scipython__code.ipynb
@@ -696,7 +696,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `linspace` function is especially useful if we want to create a particular number of evenly spaced values in a specified half-open interval:"
+    "The `linspace` function is especially useful if we want to create a particular number of evenly spaced values in a specified closed interval:"
    ]
   },
   {


### PR DESCRIPTION
Since [endpoint is True by default](https://numpy.org/doc/stable/reference/generated/numpy.linspace.html) it's more correct to say "in a specified closed interval".